### PR TITLE
Made default on !verify-study True

### DIFF
--- a/studybot.py
+++ b/studybot.py
@@ -319,7 +319,7 @@ class StudyBot(commands.Bot):
 
     @_command_list_adder
     @commands.command(name="verify-study", help=help_dict.get("verify-study"))
-    async def verify(self, value: bool):
+    async def verify(self, value: bool = True):
         if await invalid_channel(self, self.bot):
             return
         if self.channel.name != self.bot._channel_name:


### PR DESCRIPTION
I made the default on !verify-study true so !verify-study confirms without the need to include True at the end, making it more convenient. Doing !verify-study False still denies the verification.