### PR TITLE
Refactoring Studybot to be organized like a normal discord.py bot.

### DIFF
--- a/admin_cog.py
+++ b/admin_cog.py
@@ -1,0 +1,22 @@
+import discord
+from discord.ext import commands
+import studybot
+from typing import Union
+
+class Admin_Commands(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+
+    @commands.command(help=studybot.help_dict.get('shutdown'))
+    @commands.has_role(studybot.admin_role_id)
+    async def shutdown(self, ctx):
+        text = "Okay. I, {}, am shutting down"
+        await bot.change_presence(status=Status.offline)
+        await ctx.reply(text.format(self.bot.user))
+        await asyncio.sleep(10)
+        await bot.logout()
+        return
+
+def setup(bot):
+    bot.add_cog(Admin_Commands(bot))

--- a/admin_cog.py
+++ b/admin_cog.py
@@ -11,7 +11,7 @@ class Admin_Commands(commands.Cog):
     @commands.command(help=studybot.help_dict.get('shutdown'))
     @commands.has_role(studybot.admin_role_id)
     async def shutdown(self, ctx):
-        text = "Okay. I, {}, am shutting down"
+        text = 'Okay. I, {}, am shutting down'
         await bot.change_presence(status=Status.offline)
         await ctx.reply(text.format(self.bot.user))
         await asyncio.sleep(10)

--- a/studybot.py
+++ b/studybot.py
@@ -32,7 +32,8 @@ def get_token():
 
 
 def setup_database():
-    """Create the database table if it doesn't exist.
+    """Create the database table if it doesn't exist. 
+    Also defines db_conn global variable for connecting to the db.
     :return: Nothing"""
     global db_conn 
     db_conn = sqlite3.connect('server.db')
@@ -48,13 +49,11 @@ def setup_database():
 
 
 def log_writer(err: Exception, filename: str = 'error.log'):
+    """Writes to the log file 'error.log'
+    :return: Nothing"""
     with open(filename, 'a') as f:
         f.write("{}\n".format(repr(err)))
 
-
-class AltHelp(commands.DefaultHelpCommand):
-    async def send_pages(self):
-        await super().send_pages()
 
 @bot.event
 async def on_ready():
@@ -65,9 +64,12 @@ async def on_ready():
 
 setup_database()
 if __name__ == '__main__':
+    # Imports the cogs so the bot knows they exist.
     cogs = ['admin_cog', 'time_tracker_cog', 'timer_cog']
     for i in cogs:
         bot.load_extension(i)
+    # Starts the bot.
+    # Note: This blocks until the bot shuts down.
     bot.run(get_token())
 
     # Finish database stuff after the bot client disconnects.

--- a/studybot.py
+++ b/studybot.py
@@ -7,16 +7,16 @@ from contextlib import closing
 from datetime import datetime
 
 
-bot = commands.Bot(command_prefix = "!")
+bot = commands.Bot(command_prefix = '!')
 admin_role_id = 814693343236980786
 command_list = []
-help_dict = {"add-time": "Add the personal amount of study time in minutes.",
-             "get-time": "Retrieves the personal amount of hours studied.",
-             "all-time": "Retrieves the total amount of study time.",
-             "shutdown": "Shuts down the Bot. Need bot-admin.",
-             "start-timer": "Starts study timer.",
-             "stop-timer": "Stops study timer.",
-             "verify-study": "Verify the amount of study time: true or false."}
+help_dict = {'add-time': 'Add the personal amount of study time in minutes.',
+             'get-time': 'Retrieves the personal amount of hours studied.',
+             'all-time': 'Retrieves the total amount of study time.',
+             'shutdown': 'Shuts down the Bot. Need bot-admin.',
+             'start-timer': 'Starts study timer.',
+             'stop-timer': 'Stops study timer.',
+             'verify-study': 'Verify the amount of study time: true or false.'}
 lock = asyncio.Lock()
 
 
@@ -29,9 +29,9 @@ def get_token():
 
 
 def setup_database():
-    '''Create the database table if it doesn't exist.'''
+    """Create the database table if it doesn't exist."""
     global db_conn 
-    db_conn = sqlite3.connect("server.db")
+    db_conn = sqlite3.connect('server.db')
     with closing(db_conn.cursor()) as conn:
         table = 'CREATE TABLE IF NOT EXISTS study_time '
         table += '(name text, minutes integer, server text)'
@@ -43,7 +43,7 @@ def setup_database():
         db_conn.commit()
 
 
-def log_writer(err: Exception, filename: str = "error.log"):
+def log_writer(err: Exception, filename: str = 'error.log'):
     with open(filename, 'a') as f:
         f.write("{}\n".format(repr(err)))
 
@@ -53,21 +53,18 @@ class AltHelp(commands.DefaultHelpCommand):
         await super().send_pages()
 
 
-
-
-
 async def on_ready(self):
     await self.change_presence(status=Status.online)
     for server in self.guilds:
         for channel in server.channels:
             if channel.name == self._channel_name:
-                msg = "{} is online.".format(self.user)
+                msg = '{} is online.'.format(self.user)
                 await channel.send(msg)
                 return
 
 
 setup_database()
-if __name__ == "__main__":
+if __name__ == '__main__':
     cogs = ['admin_cog', 'time_tracker_cog', 'timer_cog']
     for i in cogs:
         bot.load_extension(i)

--- a/studybot.py
+++ b/studybot.py
@@ -10,6 +10,7 @@ from datetime import datetime
 bot = commands.Bot(command_prefix = '!')
 admin_role_id = 814693343236980786
 command_list = []
+# This dict is referred to for getting the descriptions of commands for the !help command.
 help_dict = {'add-time': 'Add the personal amount of study time in minutes.',
              'get-time': 'Retrieves the personal amount of hours studied.',
              'all-time': 'Retrieves the total amount of study time.',
@@ -21,6 +22,8 @@ lock = asyncio.Lock()
 
 
 def get_token():
+    """Loads environment variables from dotenv files, and returns the value of the discord token.
+    :return: String from DISCORD_TOKEN key in .env file"""
     import os
     from dotenv import load_dotenv
     load_dotenv()
@@ -29,7 +32,8 @@ def get_token():
 
 
 def setup_database():
-    """Create the database table if it doesn't exist."""
+    """Create the database table if it doesn't exist.
+    :return: Nothing"""
     global db_conn 
     db_conn = sqlite3.connect('server.db')
     with closing(db_conn.cursor()) as conn:
@@ -52,15 +56,11 @@ class AltHelp(commands.DefaultHelpCommand):
     async def send_pages(self):
         await super().send_pages()
 
-
-async def on_ready(self):
-    await self.change_presence(status=Status.online)
-    for server in self.guilds:
-        for channel in server.channels:
-            if channel.name == self._channel_name:
-                msg = '{} is online.'.format(self.user)
-                await channel.send(msg)
-                return
+@bot.event
+async def on_ready():
+    msg = '{} is online.'.format(bot.user)
+    channel = bot.get_channel(816133808533012512)
+    await channel.send(msg)
 
 
 setup_database()

--- a/studybot.py
+++ b/studybot.py
@@ -4,17 +4,11 @@ from discord import Status
 import sqlite3
 import asyncio
 from contextlib import closing
-from typing import Union
 from datetime import datetime
 
 
-def get_tokens():
-    import os
-    from dotenv import load_dotenv
-    load_dotenv()
-    return os.getenv('DISCORD_TOKEN'), os.getenv('DISCORD_GUILD')
-
-
+bot = commands.Bot(command_prefix = "!")
+admin_role_id = 814693343236980786
 command_list = []
 help_dict = {"add-time": "Add the personal amount of study time in minutes.",
              "get-time": "Retrieves the personal amount of hours studied.",
@@ -23,18 +17,30 @@ help_dict = {"add-time": "Add the personal amount of study time in minutes.",
              "start-timer": "Starts study timer.",
              "stop-timer": "Stops study timer.",
              "verify-study": "Verify the amount of study time: true or false."}
+lock = asyncio.Lock()
 
 
-def _command_list_adder(func):
-    command_list.append(func)
-    return func
+def get_token():
+    import os
+    from dotenv import load_dotenv
+    load_dotenv()
+    return(os.getenv('DISCORD_TOKEN'))
 
 
-def proper_role(self, rolename: str = "bot-admin"):
-    for role in self.author.roles:
-        if rolename in role.name:
-            return True
-    return False
+
+def setup_database():
+    '''Create the database table if it doesn't exist.'''
+    global db_conn 
+    db_conn = sqlite3.connect("server.db")
+    with closing(db_conn.cursor()) as conn:
+        table = 'CREATE TABLE IF NOT EXISTS study_time '
+        table += '(name text, minutes integer, server text)'
+        conn.execute(table)
+        db_conn.commit()
+        table = 'CREATE TABLE IF NOT EXISTS live_timer '
+        table += '(name text, server text, timestamp real)'
+        db_conn.execute(table)
+        db_conn.commit()
 
 
 def log_writer(err: Exception, filename: str = "error.log"):
@@ -42,341 +48,34 @@ def log_writer(err: Exception, filename: str = "error.log"):
         f.write("{}\n".format(repr(err)))
 
 
-def proper_channel(bot_channel: str, channels: Union[list, tuple]):
-    for channel in channels:
-        if bot_channel == channel.name:
-            return True
-    return False
-
-
-async def invalid_channel(request: commands.Context, bot: commands.Bot):
-    if request.channel.name != bot._channel_name:
-        args = (type(bot).__name__, request.channel.name, bot._channel_name)
-        await request.reply("{} doesn't respond on {}, only {}".format(*args))
-        return True
-    return False
-
-
 class AltHelp(commands.DefaultHelpCommand):
     async def send_pages(self):
-        # if not invalid_channel(self, self.bot):
         await super().send_pages()
 
 
-class StudyBot(commands.Bot):
-    _command_list = command_list
 
-    def __init__(self, *args, **kwargs):
-        self._db_conn = sqlite3.connect("server.db")
-        self._lock = asyncio.Lock()
-        self._bot_stop = False
-        self._channel_name = "bot-channel"
-        self._bot_channel()
-        super().__init__(*args, **kwargs)
-        with closing(self._db_conn.cursor()) as conn:
-            table = 'CREATE TABLE IF NOT EXISTS study_time '
-            table += '(name text, minutes integer, server text)'
-            conn.execute(table)
-            self._db_conn.commit()
-            table = 'CREATE TABLE IF NOT EXISTS live_timer '
-            table += '(name text, server text, timestamp real)'
-            conn.execute(table)
-            self._db_conn.commit()
-        for func in self._command_list:
-            self.add_command(func)
 
-    def _bot_channel(self, write: bool = False):
-        file = "channel.txt"
-        if write:
-            with open(file, 'w') as f:
-                f.write(self._channel_name)
-        else:
-            import os
-            if not os.path.exists(file):
+
+async def on_ready(self):
+    await self.change_presence(status=Status.online)
+    for server in self.guilds:
+        for channel in server.channels:
+            if channel.name == self._channel_name:
+                msg = "{} is online.".format(self.user)
+                await channel.send(msg)
                 return
-            with open(file, 'r') as f:
-                self._channel_name = f.read().strip()
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        self._db_conn.commit()
-        self._db_conn.close()
-        if not self.is_closed():
-            loop = asyncio.get_event_loop()
-            loop.run_until_complete(self.close())
-        self._bot_channel(self._channel_name)
-
-    async def on_ready(self):
-        await self.change_presence(status=Status.online)
-        for server in self.guilds:
-            for channel in server.channels:
-                if channel.name == self._channel_name:
-                    msg = "{} is online.".format(self.user)
-                    await channel.send(msg)
-                    return
-
-    @_command_list_adder
-    @commands.command(help=help_dict.get('shutdown'))
-    async def shutdown(self):
-        # Commands are context objects and have bot as an object
-        if await invalid_channel(self, self.bot):
-            return
-        if proper_role(self):
-            text = "Okay. I, {}, am shutting down"
-            await self.bot.change_presence(status=Status.offline)
-            await self.reply(text.format(self.bot.user))
-            await asyncio.sleep(10)
-            await self.bot.close()
-            await self.close()
-            return
-        msg = "Sorry, you must have the bot-admin role to shutdown this bot."
-        await self.reply(msg, delete_after=15)
-        await self.close()
-
-    @_command_list_adder
-    @commands.command(name="set-channel")
-    async def set_channel(self, name: str):
-        if await invalid_channel(self, self.bot):
-            return
-        if name not in (i.name for i in self.channel.guild.channels):
-            await self.reply("{} is not a channel on this server".format(name))
-            return
-        if proper_role(self):
-            self.bot._channel_name = name
-            await self.reply("{} is set as the StudyBot Channel.".format(name))
-        else:
-            await self.reply("You do not have the right to change the Channel")
-
-    @_command_list_adder
-    @commands.command(name="add-time", help=help_dict.get('add-time'))
-    async def add_time(self, minutes: Union[int, str] = 0):
-        if await invalid_channel(self, self.bot):
-            return
-        if self.channel.name != self.bot._channel_name:
-            args = (type(self.bot).__name__, self.channel.name, self.bot._channel_name)  # noqa: E501
-            await self.reply("{} doesn't respond on {}, only {}".format(*args))
-            return
-        if isinstance(minutes, str):
-            if not minutes.isdigit():
-                await self.reply("'{}' is not a proper value".format(minutes))
-                return
-            minutes = int(minutes)
-        if minutes < 0:
-            await self.reply("'{}' is not a proper value".format(minutes))
-            return
-        msg = "Added {} hours and {} minutes."
-        username = str(self.author)
-        with closing(self.bot._db_conn.cursor()) as conn:
-            async with self.bot._lock:
-                query = 'SELECT minutes FROM study_time WHERE name = ? AND server = ?'  # noqa: E501
-                conn.execute(query, (username, str(self.guild)))
-                if conn.fetchone() is None:
-                    query = 'INSERT INTO study_time (name, minutes, server)'
-                    query += ' VALUES (?, ?, ?)'
-                    conn.execute(query, (username, 0, str(self.guild)))
-                query = 'UPDATE study_time SET minutes = minutes + ? '
-                query += 'WHERE name = ? AND server = ?'
-                conn.execute(query, (minutes, username, str(self.guild)))
-                self.bot._db_conn.commit()
-        try:
-            await self.reply(msg.format(*divmod(minutes, 60)))  # noqa: E501
-        except Exception as e:
-            log_writer(e)
-
-    @_command_list_adder
-    @commands.command(name="get-time", help=help_dict.get('get-time'))
-    async def get_time(self):
-        if await invalid_channel(self, self.bot):
-            return
-        if self.channel.name != self.bot._channel_name:
-            args = (type(self.bot).__name__, self.channel.name, self.bot._channel_name)  # noqa: E501
-            await self.reply("{} doesn't respond on {}, only {}".format(*args))
-            return
-        username = str(self.author)
-        with closing(self.bot._db_conn.cursor()) as conn:
-            async with self.bot._lock:
-                query = 'SELECT minutes FROM study_time WHERE name = ? AND server = ?'  # noqa: E501
-                conn.execute(query, (username, str(self.guild)))
-                value = conn.fetchone()
-                if value is None:
-                    query = 'INSERT INTO study_time (name, minutes, server) '
-                    query += 'VALUES (?, ?, ?)'
-                    conn.execute(query, (username, 0, str(self.guild)))
-                    query = 'SELECT minutes FROM study_time WHERE name = ? AND server = ?'  # noqa: E501
-                    conn.execute(query, (username, str(self.guild)))
-                    value = conn.fetchone()[0]
-                else:
-                    value = value[0]
-                msg = "You have contributed {} hours and {} minutes to total."
-                await self.reply(msg.format(*divmod(value, 60)))
-                self.bot._db_conn.commit()
-
-    @_command_list_adder
-    @commands.command(name="all-time", help=help_dict.get('all-time'))
-    async def all_time(self):
-        if await invalid_channel(self, self.bot):
-            return
-        if self.channel.name != self.bot._channel_name:
-            args = (type(self.bot).__name__, self.channel.name, self.bot._channel_name)  # noqa: E501
-            await self.reply("{} doesn't respond on {}, only {}".format(*args))
-            return
-        with closing(self.bot._db_conn.cursor()) as conn:
-            async with self.bot._lock:
-                query = 'SELECT minutes FROM study_time WHERE server = ?'
-                conn.execute(query, (str(self.guild),))
-                value = sum(i[0] for i in conn.fetchall())
-                msg = "The total amount of time studying is {} hours"
-                msg += " and {} minutes."
-                await self.reply(msg.format(*divmod(value, 60)))
-                self.bot._db_conn.commit()
-
-    @_command_list_adder
-    @commands.command(name="start-timer", help=help_dict.get('start-timer'))
-    async def start_study(self):
-        if await invalid_channel(self, self.bot):
-            return
-        if self.channel.name != self.bot._channel_name:
-            args = (type(self.bot).__name__, self.channel.name, self.bot._channel_name)  # noqa: E501
-            await self.reply("{} doesn't respond on {}, only {}".format(*args))
-            return
-        timestamp = datetime.now().timestamp()
-        username, server = map(str, (self.author, self.guild))
-        with closing(self.bot._db_conn.cursor()) as conn:
-            async with self.bot._lock:
-                query = 'SELECT timestamp FROM live_timer WHERE name = ? AND server = ?'
-                conn.execute(query, (username, server))
-                result = conn.fetchone()
-                if result is None:
-                    query = 'INSERT INTO live_timer (name, server, timestamp) '
-                    query += 'VALUES (?, ?, ?)'
-                    conn.execute(query, (username, server, timestamp))
-                elif result[0] == 0.0:
-                    query = 'UPDATE live_timer SET timestamp = ? '
-                    query += 'WHERE name = ? AND server = ?'
-                    conn.execute(query, (timestamp, username, server))
-                elif bool(result[0]):
-                    await self.reply("Already started timer.", delete_after=120)
-                    self.bot._db_conn.commit()
-                    return
-                else:
-                    await self.reply("Sorry. Unexpected Error happend.")
-                    err = "In start_study, result is not None, 0.0, or timestamp."
-                    err += f"Username = {username}, Server = {server}, "
-                    err += f"timestamp = {timestamp}." 
-                    log_writer(err)
-                    self.bot._db_conn.commit()
-                    return
-        await self.reply("Okay. Started Timer.", delete_after=120)
-        self.bot._db_conn.commit()
-
-    @_command_list_adder
-    @commands.command(name="stop-timer", help=help_dict.get('stop-timer'))
-    async def stop_study(self):
-        if await invalid_channel(self, self.bot):
-            return
-        if self.channel.name != self.bot._channel_name:
-            args = (type(self.bot).__name__, self.channel.name, self.bot._channel_name)  # noqa: E501
-            await self.reply("{} doesn't respond on {}, only {}".format(*args))
-            return
-        username, server = map(str, (self.author, self.guild))
-        result = 0.0
-        minutes = 0
-        with closing(self.bot._db_conn.cursor()) as conn:
-            async with self.bot._lock:
-                query = 'SELECT timestamp FROM live_timer WHERE name = ? '
-                query += 'AND server = ?'
-                conn.execute(query, (username, server))
-                result = conn.fetchone()
-                if result is None:
-                    await self.reply("Never started timer.", delete_after=120)
-                    self.bot._db_conn.commit()
-                    return
-                elif result[0] == 0.0:
-                    await self.reply("Never started timer.", delete_after=120)
-                    self.bot._db_conn.commit()
-                    return
-                elif bool(result[0]):
-                    result = datetime.now() - datetime.fromtimestamp(result[0])
-                    minutes, seconds = divmod(result.seconds, 60)
-                    minutes += round(seconds / 60)
-                    query = 'UPDATE live_timer SET timestamp = ? '
-                    query += 'WHERE name = ? AND server = ?'
-                    conn.execute(query, (float(minutes), username, server))
-                else:
-                    await self.reply("Sorry. Unexpected Error happend.")
-                    err = "In stop_study, result is not None, 0.0, or timestamp."
-                    err += f"Username = {username} and Server = {server}"
-                    log_writer(err)
-                    self.bot._db_conn.commit()
-                    return
-        msg = "Timer is stopped. Please '!verify-study True' if {} minutes is"
-        msg += " the proper amount of study time. If false please '!verify-"
-        msg += "study False'."
-        await self.reply(msg.format(minutes), delete_after=300)
-        self.bot._db_conn.commit()
-
-    @_command_list_adder
-    @commands.command(name="verify-study", help=help_dict.get("verify-study"))
-    async def verify(self, value: bool = True):
-        if await invalid_channel(self, self.bot):
-            return
-        if self.channel.name != self.bot._channel_name:
-            args = (type(self.bot).__name__, self.channel.name, self.bot._channel_name)  # noqa: E501
-            await self.reply("{} doesn't respond on {}, only {}".format(*args))
-            return
-        username, server = map(str, (self.author, self.guild))
-        msg = "Added {} hours and {} minutes."
-        minutes = 0
-        with closing(self.bot._db_conn.cursor()) as conn:
-            async with self.bot._lock:
-                if value:
-                    query = 'SELECT timestamp FROM live_timer WHERE name = ? '
-                    query += 'AND server = ?'
-                    conn.execute(query, (username, server))
-                    result = conn.fetchone()
-                    if result[0] is None:
-                        errormsg = "Timer was never set. Cannot verify."
-                        await self.reply(errormsg, delete_after=60)
-                        self.bot._db_conn.commit()
-                        return
-                    elif result[0] == 0.0:
-                        errormsg = "Timer was never set. Cannot verify."
-                        await self.reply(errormsg, delete_after=60)
-                        self.bot._db_conn.commit()
-                        return
-                    elif bool(result[0]):
-                        if divmod(result[0], 1)[1] != 0.0:
-                            msg = "Timer was never stopped. Cannot verify."
-                            await self.reply(msg)
-                            self.bot._db_conn.commit()
-                            return
-                        result = minutes = int(result[0])
-                        query = 'UPDATE study_time SET minutes = minutes + ? '
-                        query += 'WHERE name = ? AND server = ?'
-                        conn.execute(query, (result, username, server))
-                        query = 'UPDATE live_timer SET timestamp = ? '
-                        query += 'WHERE name = ? AND server = ?'
-                        conn.execute(query, (0.0, username, server))
-                    else:
-                        await self.reply("Sorry. Unexpected Error happend.")
-                        msg = f"verify_study. Username = {username} and "
-                        msg += f"Server = {server}"
-                        log_writer(msg)
-                        self.bot._db_conn.commit()
-                        return
-                else:
-                    msg = "Okay. Discarding recorded study time."
-                    await self.reply(msg, delete_after=30)
-                    query = 'UPDATE live_timer SET timestamp = ? '
-                    query += 'WHERE name = ? AND server = ?'
-                    conn.execute(query, (0.0, username, server))
-                    return
-        self.bot._db_conn.commit()
-        await self.reply(msg.format(*divmod(minutes, 60)))
 
 
+setup_database()
 if __name__ == "__main__":
-    with StudyBot("!", AltHelp()) as bot:
-        bot.run(get_tokens()[0])
+    cogs = ['admin_cog', 'time_tracker_cog', 'timer_cog']
+    for i in cogs:
+        bot.load_extension(i)
+    bot.run(get_token())
+
+    # Finish database stuff after the bot client disconnects.
+    db_conn.commit()
+    db_conn.close()
+
+
+

--- a/time_tracker_cog.py
+++ b/time_tracker_cog.py
@@ -36,7 +36,7 @@ class Time_Tracking(commands.Cog):
         try:
             await ctx.reply(msg.format(*divmod(minutes, 60)))  # noqa: E501
         except Exception as e:
-            log_writer(e)
+            studybot.log_writer(e)
 
 
     @commands.command(name='get-time', help=studybot.help_dict.get('get-time'))

--- a/time_tracker_cog.py
+++ b/time_tracker_cog.py
@@ -9,17 +9,17 @@ class Time_Tracking(commands.Cog):
         self.bot = bot
     
 
-    @commands.command(name="add-time", help=studybot.help_dict.get('add-time'))
+    @commands.command(name='add-time', help=studybot.help_dict.get('add-time'))
     async def add_time(self, ctx, minutes: Union[int, str] = 0):
         if isinstance(minutes, str):
             if not minutes.isdigit():
-                await ctx.reply("'{}' is not a proper value".format(minutes))
+                await ctx.reply('"{}" is not a proper value'.format(minutes))
                 return
             minutes = int(minutes)
         if minutes < 0:
-            await ctx.reply("'{}' is not a proper value".format(minutes))
+            await ctx.reply('"{}" is not a proper value'.format(minutes))
             return
-        msg = "Added {} hours and {} minutes."
+        msg = 'Added {} hours and {} minutes.'
         username = str(ctx.author)
         with closing(studybot.db_conn.cursor()) as conn:
             async with studybot.lock:
@@ -39,7 +39,7 @@ class Time_Tracking(commands.Cog):
             log_writer(e)
 
 
-    @commands.command(name="get-time", help=studybot.help_dict.get('get-time'))
+    @commands.command(name='get-time', help=studybot.help_dict.get('get-time'))
     async def get_time(self, ctx):
         username = str(ctx.author)
         with closing(studybot.db_conn.cursor()) as conn:
@@ -56,20 +56,20 @@ class Time_Tracking(commands.Cog):
                     value = conn.fetchone()[0]
                 else:
                     value = value[0]
-                msg = "You have contributed {} hours and {} minutes to total."
+                msg = 'You have contributed {} hours and {} minutes to total.'
                 await ctx.reply(msg.format(*divmod(value, 60)))
                 studybot.db_conn.commit()
 
 
-    @commands.command(name="all-time", help=studybot.help_dict.get('all-time'))
+    @commands.command(name='all-time', help=studybot.help_dict.get('all-time'))
     async def all_time(self, ctx):
         with closing(studybot.db_conn.cursor()) as conn:
             async with studybot.lock:
                 query = 'SELECT minutes FROM study_time WHERE server = ?'
                 conn.execute(query, (str(ctx.guild),))
                 value = sum(i[0] for i in conn.fetchall())
-                msg = "The total amount of time studying is {} hours"
-                msg += " and {} minutes."
+                msg = 'The total amount of time studying is {} hours'
+                msg += ' and {} minutes.'
                 await ctx.reply(msg.format(*divmod(value, 60)))
                 studybot.db_conn.commit()
 

--- a/time_tracker_cog.py
+++ b/time_tracker_cog.py
@@ -1,0 +1,78 @@
+import discord
+from discord.ext import commands
+from contextlib import closing
+from typing import Union
+import studybot
+
+class Time_Tracking(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+    
+
+    @commands.command(name="add-time", help=studybot.help_dict.get('add-time'))
+    async def add_time(self, ctx, minutes: Union[int, str] = 0):
+        if isinstance(minutes, str):
+            if not minutes.isdigit():
+                await ctx.reply("'{}' is not a proper value".format(minutes))
+                return
+            minutes = int(minutes)
+        if minutes < 0:
+            await ctx.reply("'{}' is not a proper value".format(minutes))
+            return
+        msg = "Added {} hours and {} minutes."
+        username = str(ctx.author)
+        with closing(studybot.db_conn.cursor()) as conn:
+            async with studybot.lock:
+                query = 'SELECT minutes FROM study_time WHERE name = ? AND server = ?'  # noqa: E501
+                conn.execute(query, (username, str(ctx.guild)))
+                if conn.fetchone() is None:
+                    query = 'INSERT INTO study_time (name, minutes, server)'
+                    query += ' VALUES (?, ?, ?)'
+                    conn.execute(query, (username, 0, str(ctx.guild)))
+                query = 'UPDATE study_time SET minutes = minutes + ? '
+                query += 'WHERE name = ? AND server = ?'
+                conn.execute(query, (minutes, username, str(ctx.guild)))
+                studybot.db_conn.commit()
+        try:
+            await ctx.reply(msg.format(*divmod(minutes, 60)))  # noqa: E501
+        except Exception as e:
+            log_writer(e)
+
+
+    @commands.command(name="get-time", help=studybot.help_dict.get('get-time'))
+    async def get_time(self, ctx):
+        username = str(ctx.author)
+        with closing(studybot.db_conn.cursor()) as conn:
+            async with studybot.lock:
+                query = 'SELECT minutes FROM study_time WHERE name = ? AND server = ?'  # noqa: E501
+                conn.execute(query, (username, str(ctx.guild)))
+                value = conn.fetchone()
+                if value is None:
+                    query = 'INSERT INTO study_time (name, minutes, server) '
+                    query += 'VALUES (?, ?, ?)'
+                    conn.execute(query, (username, 0, str(ctx.guild)))
+                    query = 'SELECT minutes FROM study_time WHERE name = ? AND server = ?'  # noqa: E501
+                    conn.execute(query, (username, str(ctx.guild)))
+                    value = conn.fetchone()[0]
+                else:
+                    value = value[0]
+                msg = "You have contributed {} hours and {} minutes to total."
+                await ctx.reply(msg.format(*divmod(value, 60)))
+                studybot.db_conn.commit()
+
+
+    @commands.command(name="all-time", help=studybot.help_dict.get('all-time'))
+    async def all_time(self, ctx):
+        with closing(studybot.db_conn.cursor()) as conn:
+            async with studybot.lock:
+                query = 'SELECT minutes FROM study_time WHERE server = ?'
+                conn.execute(query, (str(ctx.guild),))
+                value = sum(i[0] for i in conn.fetchall())
+                msg = "The total amount of time studying is {} hours"
+                msg += " and {} minutes."
+                await ctx.reply(msg.format(*divmod(value, 60)))
+                studybot.db_conn.commit()
+
+
+def setup(bot):
+    bot.add_cog(Time_Tracking(bot))

--- a/timer_cog.py
+++ b/timer_cog.py
@@ -35,7 +35,7 @@ class Study_Timer(commands.Cog):
                     err = 'In start_study, result is not None, 0.0, or timestamp.'
                     err += f'Username = {username}, Server = {server}, '
                     err += f'timestamp = {timestamp}.'
-                    log_writer(err)
+                    studybot.log_writer(err)
                     studybot.db_conn.commit()
                     return
         await ctx.reply('Okay. Started Timer.', delete_after=120)
@@ -72,7 +72,7 @@ class Study_Timer(commands.Cog):
                     await ctx.reply('Sorry. Unexpected Error happend.')
                     err = 'In stop_study, result is not None, 0.0, or timestamp.'
                     err += f'Username = {username} and Server = {server}'
-                    log_writer(err)
+                    studybot.log_writer(err)
                     studybot.db_conn.commit()
                     return
         msg = 'Timer is stopped. Please "!verify-study" if {} minutes is'
@@ -121,7 +121,7 @@ class Study_Timer(commands.Cog):
                         await ctx.reply('Sorry. Unexpected Error happend.')
                         msg = f'verify_study. Username = {username} and '
                         msg += f'Server = {server}'
-                        log_writer(msg)
+                        studybot.log_writer(msg)
                         studybot.db_conn.commit()
                         return
                 else:

--- a/timer_cog.py
+++ b/timer_cog.py
@@ -1,0 +1,139 @@
+import discord
+from discord.ext import commands
+import studybot
+from datetime import datetime
+from contextlib import closing
+from typing import Union
+
+class Study_Timer(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+    
+    @commands.command(name="start-timer", help=studybot.help_dict.get('start-timer'))
+    async def start_study(self, ctx):
+        timestamp = datetime.now().timestamp()
+        username, server = map(str, (ctx.author, ctx.guild))
+        with closing(studybot.db_conn.cursor()) as conn:
+            async with studybot.lock:
+                query = 'SELECT timestamp FROM live_timer WHERE name = ? AND server = ?'
+                conn.execute(query, (username, server))
+                result = conn.fetchone()
+                if result is None:
+                    query = 'INSERT INTO live_timer (name, server, timestamp) '
+                    query += 'VALUES (?, ?, ?)'
+                    conn.execute(query, (username, server, timestamp))
+                elif result[0] == 0.0:
+                    query = 'UPDATE live_timer SET timestamp = ? '
+                    query += 'WHERE name = ? AND server = ?'
+                    conn.execute(query, (timestamp, username, server))
+                elif bool(result[0]):
+                    await ctx.reply("Already started timer.", delete_after=120)
+                    studybot.db_conn.commit()
+                    return
+                else:
+                    await ctx.reply("Sorry. Unexpected Error happend.")
+                    err = "In start_study, result is not None, 0.0, or timestamp."
+                    err += f"Username = {username}, Server = {server}, "
+                    err += f"timestamp = {timestamp}." 
+                    log_writer(err)
+                    studybot.db_conn.commit()
+                    return
+        await ctx.reply("Okay. Started Timer.", delete_after=120)
+        studybot.db_conn.commit()
+
+
+    @commands.command(name="stop-timer", help=studybot.help_dict.get('stop-timer'))
+    async def stop_study(self, ctx):
+        username, server = map(str, (ctx.author, ctx.guild))
+        result = 0.0
+        minutes = 0
+        with closing(studybot.db_conn.cursor()) as conn:
+            async with studybot.lock:
+                query = 'SELECT timestamp FROM live_timer WHERE name = ? '
+                query += 'AND server = ?'
+                conn.execute(query, (username, server))
+                result = conn.fetchone()
+                if result is None:
+                    await ctx.reply("Never started timer.", delete_after=120)
+                    studybot.db_conn.commit()
+                    return
+                elif result[0] == 0.0:
+                    await ctx.reply("Never started timer.", delete_after=120)
+                    studybot.db_conn.commit()
+                    return
+                elif bool(result[0]):
+                    result = datetime.now() - datetime.fromtimestamp(result[0])
+                    minutes, seconds = divmod(result.seconds, 60)
+                    minutes += round(seconds / 60)
+                    query = 'UPDATE live_timer SET timestamp = ? '
+                    query += 'WHERE name = ? AND server = ?'
+                    conn.execute(query, (float(minutes), username, server))
+                else:
+                    await ctx.reply("Sorry. Unexpected Error happend.")
+                    err = "In stop_study, result is not None, 0.0, or timestamp."
+                    err += f"Username = {username} and Server = {server}"
+                    log_writer(err)
+                    studybot.db_conn.commit()
+                    return
+        msg = "Timer is stopped. Please '!verify-study' if {} minutes is"
+        msg += " the proper amount of study time. If false please '!verify-"
+        msg += "study False'."
+        await ctx.reply(msg.format(minutes), delete_after=300)
+        studybot.db_conn.commit()
+
+
+    @commands.command(name="verify-study", help=studybot.help_dict.get("verify-study"))
+    async def verify(self, ctx, value: bool = True):
+        username, server = map(str, (ctx.author, ctx.guild))
+        msg = "Added {} hours and {} minutes."
+        minutes = 0
+        with closing(studybot.db_conn.cursor()) as conn:
+            async with studybot.lock:
+                if value:
+                    query = 'SELECT timestamp FROM live_timer WHERE name = ? '
+                    query += 'AND server = ?'
+                    conn.execute(query, (username, server))
+                    result = conn.fetchone()
+                    if result[0] is None:
+                        errormsg = "Timer was never set. Cannot verify."
+                        await ctx.reply(errormsg, delete_after=60)
+                        studybot.db_conn.commit()
+                        return
+                    elif result[0] == 0.0:
+                        errormsg = "Timer was never set. Cannot verify."
+                        await ctx.reply(errormsg, delete_after=60)
+                        studybot.db_conn.commit()
+                        return
+                    elif bool(result[0]):
+                        if divmod(result[0], 1)[1] != 0.0:
+                            msg = "Timer was never stopped. Cannot verify."
+                            await ctx.reply(msg)
+                            studybot.db_conn.commit()
+                            return
+                        result = minutes = int(result[0])
+                        query = 'UPDATE study_time SET minutes = minutes + ? '
+                        query += 'WHERE name = ? AND server = ?'
+                        conn.execute(query, (result, username, server))
+                        query = 'UPDATE live_timer SET timestamp = ? '
+                        query += 'WHERE name = ? AND server = ?'
+                        conn.execute(query, (0.0, username, server))
+                    else:
+                        await ctx.reply("Sorry. Unexpected Error happend.")
+                        msg = f"verify_study. Username = {username} and "
+                        msg += f"Server = {server}"
+                        log_writer(msg)
+                        studybot.db_conn.commit()
+                        return
+                else:
+                    msg = "Okay. Discarding recorded study time."
+                    await ctx.reply(msg, delete_after=30)
+                    query = 'UPDATE live_timer SET timestamp = ? '
+                    query += 'WHERE name = ? AND server = ?'
+                    conn.execute(query, (0.0, username, server))
+                    return
+        studybot.db_conn.commit()
+        await ctx.reply(msg.format(*divmod(minutes, 60)))
+
+
+def setup(bot):
+    bot.add_cog(Study_Timer(bot))

--- a/timer_cog.py
+++ b/timer_cog.py
@@ -9,7 +9,7 @@ class Study_Timer(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
     
-    @commands.command(name="start-timer", help=studybot.help_dict.get('start-timer'))
+    @commands.command(name='start-timer', help=studybot.help_dict.get('start-timer'))
     async def start_study(self, ctx):
         timestamp = datetime.now().timestamp()
         username, server = map(str, (ctx.author, ctx.guild))
@@ -27,22 +27,22 @@ class Study_Timer(commands.Cog):
                     query += 'WHERE name = ? AND server = ?'
                     conn.execute(query, (timestamp, username, server))
                 elif bool(result[0]):
-                    await ctx.reply("Already started timer.", delete_after=120)
+                    await ctx.reply('Already started timer.', delete_after=120)
                     studybot.db_conn.commit()
                     return
                 else:
-                    await ctx.reply("Sorry. Unexpected Error happend.")
-                    err = "In start_study, result is not None, 0.0, or timestamp."
-                    err += f"Username = {username}, Server = {server}, "
-                    err += f"timestamp = {timestamp}." 
+                    await ctx.reply('Sorry. Unexpected Error happend.')
+                    err = 'In start_study, result is not None, 0.0, or timestamp.'
+                    err += f'Username = {username}, Server = {server}, '
+                    err += f'timestamp = {timestamp}.'
                     log_writer(err)
                     studybot.db_conn.commit()
                     return
-        await ctx.reply("Okay. Started Timer.", delete_after=120)
+        await ctx.reply('Okay. Started Timer.', delete_after=120)
         studybot.db_conn.commit()
 
 
-    @commands.command(name="stop-timer", help=studybot.help_dict.get('stop-timer'))
+    @commands.command(name='stop-timer', help=studybot.help_dict.get('stop-timer'))
     async def stop_study(self, ctx):
         username, server = map(str, (ctx.author, ctx.guild))
         result = 0.0
@@ -54,11 +54,11 @@ class Study_Timer(commands.Cog):
                 conn.execute(query, (username, server))
                 result = conn.fetchone()
                 if result is None:
-                    await ctx.reply("Never started timer.", delete_after=120)
+                    await ctx.reply('Never started timer.', delete_after=120)
                     studybot.db_conn.commit()
                     return
                 elif result[0] == 0.0:
-                    await ctx.reply("Never started timer.", delete_after=120)
+                    await ctx.reply('Never started timer.', delete_after=120)
                     studybot.db_conn.commit()
                     return
                 elif bool(result[0]):
@@ -69,23 +69,23 @@ class Study_Timer(commands.Cog):
                     query += 'WHERE name = ? AND server = ?'
                     conn.execute(query, (float(minutes), username, server))
                 else:
-                    await ctx.reply("Sorry. Unexpected Error happend.")
-                    err = "In stop_study, result is not None, 0.0, or timestamp."
-                    err += f"Username = {username} and Server = {server}"
+                    await ctx.reply('Sorry. Unexpected Error happend.')
+                    err = 'In stop_study, result is not None, 0.0, or timestamp.'
+                    err += f'Username = {username} and Server = {server}'
                     log_writer(err)
                     studybot.db_conn.commit()
                     return
-        msg = "Timer is stopped. Please '!verify-study' if {} minutes is"
-        msg += " the proper amount of study time. If false please '!verify-"
-        msg += "study False'."
+        msg = 'Timer is stopped. Please "!verify-study" if {} minutes is'
+        msg += ' the proper amount of study time. If false please "!verify-'
+        msg += 'study False".'
         await ctx.reply(msg.format(minutes), delete_after=300)
         studybot.db_conn.commit()
 
 
-    @commands.command(name="verify-study", help=studybot.help_dict.get("verify-study"))
+    @commands.command(name='verify-study', help=studybot.help_dict.get('verify-study'))
     async def verify(self, ctx, value: bool = True):
         username, server = map(str, (ctx.author, ctx.guild))
-        msg = "Added {} hours and {} minutes."
+        msg = 'Added {} hours and {} minutes.'
         minutes = 0
         with closing(studybot.db_conn.cursor()) as conn:
             async with studybot.lock:
@@ -95,18 +95,18 @@ class Study_Timer(commands.Cog):
                     conn.execute(query, (username, server))
                     result = conn.fetchone()
                     if result[0] is None:
-                        errormsg = "Timer was never set. Cannot verify."
+                        errormsg = 'Timer was never set. Cannot verify.'
                         await ctx.reply(errormsg, delete_after=60)
                         studybot.db_conn.commit()
                         return
                     elif result[0] == 0.0:
-                        errormsg = "Timer was never set. Cannot verify."
+                        errormsg = 'Timer was never set. Cannot verify.'
                         await ctx.reply(errormsg, delete_after=60)
                         studybot.db_conn.commit()
                         return
                     elif bool(result[0]):
                         if divmod(result[0], 1)[1] != 0.0:
-                            msg = "Timer was never stopped. Cannot verify."
+                            msg = 'Timer was never stopped. Cannot verify.'
                             await ctx.reply(msg)
                             studybot.db_conn.commit()
                             return
@@ -118,14 +118,14 @@ class Study_Timer(commands.Cog):
                         query += 'WHERE name = ? AND server = ?'
                         conn.execute(query, (0.0, username, server))
                     else:
-                        await ctx.reply("Sorry. Unexpected Error happend.")
-                        msg = f"verify_study. Username = {username} and "
-                        msg += f"Server = {server}"
+                        await ctx.reply('Sorry. Unexpected Error happend.')
+                        msg = f'verify_study. Username = {username} and '
+                        msg += f'Server = {server}'
                         log_writer(msg)
                         studybot.db_conn.commit()
                         return
                 else:
-                    msg = "Okay. Discarding recorded study time."
+                    msg = 'Okay. Discarding recorded study time.'
                     await ctx.reply(msg, delete_after=30)
                     query = 'UPDATE live_timer SET timestamp = ? '
                     query += 'WHERE name = ? AND server = ?'


### PR DESCRIPTION
I've refactored StudyBot almost entirely.

- Studybot now uses the standard discord.py Bot class instead of StudyBot subclass
- Studybot is now organized into discord.py Cogs.
- Documentation was improved, at least a bit, to make future contributions by others easier.
- The parts of the code that required the bot to be used in a specific channel have been removed, in favor of just restricting the bot's view permissions in the server, for simplicity and readability sake. 

I tested everything on my test bot and server, and every command worked perfectly.