### PR TITLE
Created GitHub integration with the GitHub org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # StudyBot
-Python3 Discord Bot
+StudyBot is a Discord Bot written in Python 3 using discord.py.
+Originally developed for use in the [Python Practice Discord](htps://discord.gg/UBUx88xVZh), 
+StudyBot if Free and Open-Source. 
+
+StudyBot has a few basic features:
+- Users can add time to the study time counter with !add-time
+- Users can check their personal study time counter, or the global study time counter with !get-time and !all-time
+- Users can invite themselves to a linked GitHub organization with !github-join
+
+## Usage
+- Clone this repository to your local environment.
+- Install the project requirements in `requirements.txt`
+- Create a `.env` file with the following key-value pairs in the root directory:
+    - DISCORD_TOKEN
+    - ADMIN_ROLE_ID
+    - CHANNEL_ID
+    - GITHUB_ORG_NAME
+    - GITHUB_API_KEY
+- Run `studybot.py`

--- a/github_cog.py
+++ b/github_cog.py
@@ -1,11 +1,12 @@
 import discord
 from discord.ext import commands
 from github import Github
+import github
 from contextlib import closing
 import studybot
 
 
-def check_prev_inv(discord_user):
+async def check_prev_inv(discord_user):
     """
     Checks the database to see if/who a specific discord user has invited to the github organization.
     :param discord_user: discord.User object.
@@ -36,20 +37,20 @@ class GitHubIntegration(commands.Cog, name='GitHub Integration'):
             # Get the user object.
             try:
                 github_user = github_session.get_user(github_name)
-            except:
+            except github.UnknownObjectException:
                 await ctx.message.reply('The GitHub user you requested cannot be found. Double-Check your spelling.')
                 return
             # Get the organization object.
             try:
                 placement_org = github_session.get_organization(studybot.github_org_name)
-            except:
+            except github.UnknownObjextException:
                 msg = 'The GitHub organization cannot be found. Please try again later, '
                 msg += 'or contact a mod if the issue persists.'
                 await ctx.message.reply(msg)
                 return
 
             # Verify that the user has not already invited a GitHub account to the org.
-        if check_prev_inv(ctx.author) is None:
+        if await check_prev_inv(ctx.author) is None:
             # Verify that the user is not already in the org.
             if placement_org.has_in_members(github_user):
                 await ctx.message.reply('That user is already in the organization, and cannot be invited.')
@@ -80,7 +81,7 @@ class GitHubIntegration(commands.Cog, name='GitHub Integration'):
             return
 
         # Find who the user previously invited to the org.
-        db_output = check_prev_inv(discord_user)
+        db_output = await check_prev_inv(discord_user)
         # If the user hasn't invited anyone
         if db_output is None:
             await ctx.message.reply('This user has not invited anyone to the org.')
@@ -90,12 +91,12 @@ class GitHubIntegration(commands.Cog, name='GitHub Integration'):
         # Get the GitHub user object.
         try:
             g_user = g.get_user_by_id(int(db_output[0]))
-        except:
+        except github.UnknownObjextException:
             g_user = None
         # Get the GitHub organization object.
         try:
             g_org = g.get_organization(studybot.github_org_name)
-        except:
+        except github.UnknownObjectException:
             msg = 'The GitHub organization cannot be found. Please try again later.'
             await ctx.message.reply(msg)
             return

--- a/github_cog.py
+++ b/github_cog.py
@@ -54,6 +54,7 @@ class GitHub_Integration(commands.Cog):
                         # Add the Discord ID and the GitHub ID to the database table
                         query = 'INSERT INTO github_invites (discord_id, github_id) VALUES (?, ?)'
                         conn.execute(query, (ctx.author.id, g_user.id))
+                        studybot.db_conn.commit()
 
                         # Send a confirmation message in Discord.
                         await ctx.message.reply(f'Invited {g_user.login} to the GitHub Organization.')
@@ -61,7 +62,6 @@ class GitHub_Integration(commands.Cog):
                         msg = f'Cannot invite {g_user.login} to the organization, because you have already invited '
                         msg += 'another GitHub account. Please contact a moderator if this is a mistake.'
                         await ctx.message.reply(msg)
-                    studybot.db_conn.commit()
 
     @commands.command(name='github-reset', help=studybot.help_dict.get('github-reset'))
     @commands.has_role(studybot.admin_role_id)

--- a/github_cog.py
+++ b/github_cog.py
@@ -43,16 +43,13 @@ class GitHub_Integration(commands.Cog):
                     conn.execute(query, (ctx.author.id, ))
                     value = conn.fetchone()
                     if value is None:
-
-                        # Invite the user to the organization.
-                        try:
-                            g_org.invite_user(g_user)
-                        except:
-                            msg = 'An unknown error occurred, and the user was not invited. '
-                            msg += 'Make sure that the account is not already in the GitHub Org, and contact a mod if '
-                            msg += 'the issue persists.'
-                            await ctx.message.reply(msg)
+                        # Verify that the user is not already in the org.
+                        if g_org.has_in_members(g_user):
+                            await ctx.message.reply('That user is already in the organization, and cannot be invited.')
                             return()
+                        # Invite the user to the organization.
+                        else:
+                            g_org.invite_user(g_user)
 
                         # Add the Discord ID and the GitHub ID to the database table
                         query = 'INSERT INTO github_invites (discord_id, github_id) VALUES (?, ?)'

--- a/github_cog.py
+++ b/github_cog.py
@@ -15,8 +15,8 @@ def check_prev_inv(discord_user):
         async with studybot.lock:
             query = 'SELECT github_id FROM github_invites WHERE discord_id = ?'
             conn.execute(query, (discord_user.id,))
-            value = conn.fetchone()
-            return value
+            db_output = conn.fetchone()
+            return db_output
 
 
 class GitHubIntegration(commands.Cog, name='GitHub Integration'):
@@ -80,16 +80,16 @@ class GitHubIntegration(commands.Cog, name='GitHub Integration'):
             return
 
         # Find who the user previously invited to the org.
-        value = check_prev_inv(discord_user)
+        db_output = check_prev_inv(discord_user)
         # If the user hasn't invited anyone
-        if value is None:
+        if db_output is None:
             await ctx.message.reply('This user has not invited anyone to the org.')
             return
 
         g = Github(studybot.TOKENS.get('GITHUB_API_KEY'))
         # Get the GitHub user object.
         try:
-            g_user = g.get_user_by_id(int(value[0]))
+            g_user = g.get_user_by_id(int(db_output[0]))
         except:
             g_user = None
         # Get the GitHub organization object.

--- a/github_cog.py
+++ b/github_cog.py
@@ -44,8 +44,8 @@ class GitHubIntegration(commands.Cog, name='GitHub Integration'):
             try:
                 placement_org = github_session.get_organization(studybot.github_org_name)
             except github.UnknownObjextException:
-                msg = 'The GitHub organization cannot be found. Please try again later, '
-                msg += 'or contact a mod if the issue persists.'
+                msg = 'The GitHub organization you are trying to join cannot be found.'
+                msg += ' Please try again later, and contact a mod if the issue persists.'
                 await ctx.message.reply(msg)
                 return
 

--- a/github_cog.py
+++ b/github_cog.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands
 from github import Github
-import closing
+from contextlib import closing
 import studybot
 
 
@@ -19,28 +19,39 @@ class GitHub_Integration(commands.Cog):
             return
         else:
             g = Github(studybot.TOKENS.get('GITHUB_API_KEY'))
-            # Get the Organization object and the user object.
-            g_user = g.get_user(github_name)
-            g_org = g.get_organization(studybot.TOKENS.get('GITHUB_ORG_NAME'))
+            # Get the user object.
+            try:
+                g_user = g.get_user(github_name)
+            except:
+                await ctx.message.reply('The GitHub user you requested cannot be found. Double-Check your spelling.')
+                return()
+            # Get the organization object.
+            try:
+                g_org = g.get_organization(studybot.TOKENS.get('GITHUB_ORG_NAME'))
+            except:
+                msg = 'The GitHub organization cannot be found. Please try again later, '
+                msg += 'or contact a mod if the issue persists.'
+                await ctx.message.reply(msg)
+                return()
 
             # Verify that the user has not already invited a GitHub account to the org.
             with closing(studybot.db_conn.cursor()) as conn:
                 async with studybot.lock:
-                    query = 'SELECT github_id FROM github_invites WHERE discord_id = ?'  # noqa: E501
-                    conn.execute(query, ctx.author.id)
+                    query = 'SELECT github_id FROM github_invites WHERE discord_id = ?'
+                    conn.execute(query, (ctx.author.id, ))
                     value = conn.fetchone()
                     if value is None:
                         # Invite the user to the organization.
                         g_org.invite_user(g_user)
                         # Add the Discord ID and the GitHub ID to the database table
-                        query = 'INSERT INTO study_time (discord_id, github_id) VALUES (?, ?)'
+                        query = 'INSERT INTO github_invites (discord_id, github_id) VALUES (?, ?)'
                         conn.execute(query, (ctx.author.id, g_user.id))
                         # Send a confirmation message in Discord.
-                        ctx.message.reply(f'Invited {g_user.name} to the GitHub Organization.')
+                        await ctx.message.reply(f'Invited {g_user.name} to the GitHub Organization.')
                     else:
-                        msg = f'Cannot invite {g_user.name} to the organization, because you have already invited '
+                        msg = f'Cannot invite {g_user.login} to the organization, because you have already invited '
                         msg += 'another GitHub account. Please contact a moderator if this is a mistake.'
-                        ctx.message.reply(msg)
+                        await ctx.message.reply(msg)
                     studybot.db_conn.commit()
 
 

--- a/github_cog.py
+++ b/github_cog.py
@@ -1,29 +1,47 @@
 import discord
 from discord.ext import commands
 from github import Github
+import closing
 import studybot
+
 
 class GitHub_Integration(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-    
 
     @commands.command(name='github-join', help=studybot.help_dict.get('github-join'))
-    async def join(self, ctx, github_name = 'null'):
+    async def join(self, ctx, github_name='null'):
         # Make sure they included the github_name arg, and send a response.
         if github_name == 'null':
-            msg = ('You need to include your GitHub Username like this: ')
-            msg += ('`!github-join StudyBot`')
+            msg = 'You need to include your GitHub Username like this: '
+            msg += '`!github-join StudyBot`'
             await ctx.message.reply(msg)
             return
         else:
             g = Github(studybot.TOKENS.get('GITHUB_API_KEY'))
             # Get the Organization object and the user object.
             g_user = g.get_user(github_name)
-            g_org = g.get_organization('Python-Practice-Discord')
-            # Invite the user to the organization.
-            g_org.invite_user(g_user)
-            ctx.message.reply(f'Invited {g_user.name} to the Python-Practice-Discord GitHub Organization.')
+            g_org = g.get_organization(studybot.TOKENS.get('GITHUB_ORG_NAME'))
+
+            # Verify that the user has not already invited a GitHub account to the org.
+            with closing(studybot.db_conn.cursor()) as conn:
+                async with studybot.lock:
+                    query = 'SELECT github_id FROM github_invites WHERE discord_id = ?'  # noqa: E501
+                    conn.execute(query, ctx.author.id)
+                    value = conn.fetchone()
+                    if value is None:
+                        # Invite the user to the organization.
+                        g_org.invite_user(g_user)
+                        # Add the Discord ID and the GitHub ID to the database table
+                        query = 'INSERT INTO study_time (discord_id, github_id) VALUES (?, ?)'
+                        conn.execute(query, (ctx.author.id, g_user.id))
+                        # Send a confirmation message in Discord.
+                        ctx.message.reply(f'Invited {g_user.name} to the GitHub Organization.')
+                    else:
+                        msg = f'Cannot invite {g_user.name} to the organization, because you have already invited '
+                        msg += 'another GitHub account. Please contact a moderator if this is a mistake.'
+                        ctx.message.reply(msg)
+                    studybot.db_conn.commit()
 
 
 def setup(bot):

--- a/github_cog.py
+++ b/github_cog.py
@@ -19,7 +19,7 @@ def check_prev_inv(discord_user):
             return value
 
 
-class GitHub_Integration(commands.Cog):
+class GitHubIntegration(commands.Cog, name='GitHub Integration'):
     def __init__(self, bot):
         self.bot = bot
 
@@ -114,4 +114,4 @@ class GitHub_Integration(commands.Cog):
 
 
 def setup(bot):
-    bot.add_cog(GitHub_Integration(bot))
+    bot.add_cog(GitHubIntegration(bot))

--- a/github_cog.py
+++ b/github_cog.py
@@ -12,9 +12,9 @@ class GitHub_Integration(commands.Cog):
         self.bot = bot
 
     @commands.command(name='github-join', help=studybot.help_dict.get('github-join'))
-    async def join(self, ctx, github_name='null'):
+    async def join(self, ctx, github_name=None):
         # Make sure they included the github_name arg, and send a response.
-        if github_name == 'null':
+        if not github_name:
             msg = 'You need to include your GitHub Username like this: '
             msg += '`!github-join StudyBot`'
             await ctx.message.reply(msg)

--- a/github_cog.py
+++ b/github_cog.py
@@ -1,0 +1,30 @@
+import discord
+from discord.ext import commands
+from github import Github
+import studybot
+
+class GitHub_Integration(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+    
+
+    @commands.command(name='github-join', help=studybot.help_dict.get('github-join'))
+    async def join(self, ctx, github_name = 'null'):
+        # Make sure they included the github_name arg, and send a response.
+        if github_name == 'null':
+            msg = ('You need to include your GitHub Username like this: ')
+            msg += ('`!github-join StudyBot`')
+            await ctx.message.reply(msg)
+            return
+        else:
+            g = Github(studybot.TOKENS.get('GITHUB_API_KEY'))
+            # Get the Organization object and the user object.
+            g_user = g.get_user(github_name)
+            g_org = g.get_organization('Python-Practice-Discord')
+            # Invite the user to the organization.
+            g_org.invite_user(g_user)
+            ctx.message.reply(f'Invited {g_user.name} to the Python-Practice-Discord GitHub Organization.')
+
+
+def setup(bot):
+    bot.add_cog(GitHub_Integration(bot))

--- a/github_cog.py
+++ b/github_cog.py
@@ -26,7 +26,7 @@ class GitHub_Integration(commands.Cog):
                 g_user = g.get_user(github_name)
             except:
                 await ctx.message.reply('The GitHub user you requested cannot be found. Double-Check your spelling.')
-                return()
+                return
             # Get the organization object.
             try:
                 g_org = g.get_organization(studybot.github_org_name)
@@ -34,7 +34,7 @@ class GitHub_Integration(commands.Cog):
                 msg = 'The GitHub organization cannot be found. Please try again later, '
                 msg += 'or contact a mod if the issue persists.'
                 await ctx.message.reply(msg)
-                return()
+                return
 
             # Verify that the user has not already invited a GitHub account to the org.
             with closing(studybot.db_conn.cursor()) as conn:
@@ -46,7 +46,7 @@ class GitHub_Integration(commands.Cog):
                         # Verify that the user is not already in the org.
                         if g_org.has_in_members(g_user):
                             await ctx.message.reply('That user is already in the organization, and cannot be invited.')
-                            return()
+                            return
                         # Invite the user to the organization.
                         else:
                             g_org.invite_user(g_user)
@@ -68,7 +68,7 @@ class GitHub_Integration(commands.Cog):
     async def reset_user(self, ctx, discord_user: discord.User = None):
         if not discord_user:
             await ctx.message.reply('You need to tag the user to reset their abilities.')
-            return()
+            return
 
         # Find who the user previously invited to the org.
         with closing(studybot.db_conn.cursor()) as conn:
@@ -80,7 +80,7 @@ class GitHub_Integration(commands.Cog):
                 # If the user hasn't invited anyone
                 if value is None:
                     await ctx.message.reply('This user has not invited anyone to the org.')
-                    return()
+                    return
 
                 g = Github(studybot.TOKENS.get('GITHUB_API_KEY'))
                 # Get the GitHub user object.
@@ -94,7 +94,7 @@ class GitHub_Integration(commands.Cog):
                 except:
                     msg = 'The GitHub organization cannot be found. Please try again later.'
                     await ctx.message.reply(msg)
-                    return ()
+                    return
 
                 # Revoke the GitHub account's invite or remove them from the Organization (if the user exists).
                 if g_user:

--- a/github_cog.py
+++ b/github_cog.py
@@ -24,7 +24,7 @@ class GitHubIntegration(commands.Cog, name='GitHub Integration'):
         self.bot = bot
 
     @commands.command(name='github-join', help=studybot.help_dict.get('github-join'))
-    async def join(self, ctx, github_name=None):
+    async def join(self, ctx: commands.Context, github_name=None) -> None:
         # Make sure they included the github_name arg, and send a response.
         if not github_name:
             msg = 'You need to include your GitHub Username like this: '
@@ -74,7 +74,7 @@ class GitHubIntegration(commands.Cog, name='GitHub Integration'):
 
     @commands.command(name='github-reset', help=studybot.help_dict.get('github-reset'))
     @commands.has_role(studybot.admin_role_id)
-    async def reset_user(self, ctx, discord_user: discord.User = None):
+    async def reset_user(self, ctx: commands.Context, discord_user: discord.User = None) -> None:
         if not discord_user:
             await ctx.message.reply('You need to tag the user to reset their abilities.')
             return

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 discord.py
 python-dotenv
+pygithub

--- a/studybot.py
+++ b/studybot.py
@@ -14,17 +14,18 @@ help_dict = {'add-time': 'Add the personal amount of study time in minutes.',
              'shutdown': 'Shuts down the Bot. Need bot-admin.',
              'start-timer': 'Starts study timer.',
              'stop-timer': 'Stops study timer.',
-             'verify-study': 'Verify the amount of study time: true or false.'}
+             'verify-study': 'Verify the amount of study time: true or false.',
+             'github-join': 'Invites your GitHub account to our GitHub organization.'}
 lock = asyncio.Lock()
 
 
 def get_tokens() -> Dict[str, str]:
-    """Loads environment variables from dotenv files, and returns the value of the discord token.
-    :return: Dictionary from DISCORD_TOKEN, ADMIN_ROLE_ID, and CHANNEL_ID key in .env file"""
+    """Loads environment variables from dotenv files, and returns them.
+    :return: Dictionary containing DISCORD_TOKEN, ADMIN_ROLE_ID, CHANNEL_ID, and GITHUB_API_KEY key in .env file"""
     import os
     from dotenv import load_dotenv
     load_dotenv()
-    env_keys = ("DISCORD_TOKEN", "ADMIN_ROLE_ID", "CHANNEL_ID")
+    env_keys = ("DISCORD_TOKEN", "ADMIN_ROLE_ID", "CHANNEL_ID", "GITHUB_API_KEY")
     return {key: os.getenv(key) for key in env_keys}
 
 
@@ -67,7 +68,7 @@ db_conn = setup_database()
 
 if __name__ == '__main__':
     # Imports the cogs so the bot knows they exist.
-    cogs = {'admin_cog', 'time_tracker_cog', 'timer_cog'}
+    cogs = {'admin_cog', 'time_tracker_cog', 'timer_cog', 'github_cog'}
     for i in cogs:
         bot.load_extension(i)
     # Starts the bot.

--- a/studybot.py
+++ b/studybot.py
@@ -19,7 +19,8 @@ help_dict = {'add-time': 'Add the personal amount of study time in minutes.',
              'start-timer': 'Starts study timer.',
              'stop-timer': 'Stops study timer.',
              'verify-study': 'Verify the amount of study time: true or false.',
-             'github-join': 'Invites your GitHub account to our GitHub organization.'}
+             'github-join': 'Invites your GitHub account to our GitHub organization.',
+             'github-reset': 'Allows a blocked user to invite an account it the org. Tag the user. Need bot-admin.'}
 lock = asyncio.Lock()
 
 
@@ -36,6 +37,7 @@ def get_tokens() -> Dict[str, str]:
 
 TOKENS = get_tokens()
 admin_role_id = int(TOKENS.get("ADMIN_ROLE_ID"))
+github_org_name = TOKENS.get("GITHUB_ORG_NAME")
 
 
 def setup_database() -> sqlite3.Connection:
@@ -53,7 +55,7 @@ def setup_database() -> sqlite3.Connection:
         table = 'CREATE TABLE IF NOT EXISTS live_timer '
         table += '(id integer, server text, timestamp real)'
         db_conn.execute(table)
-        db_conn.commit
+        db_conn.commit()
         # Create github_invites database table.
         table = 'CREATE TABLE IF NOT EXISTS github_invites'
         table += '(discord_id integer, github_id integer)'

--- a/studybot.py
+++ b/studybot.py
@@ -21,11 +21,12 @@ lock = asyncio.Lock()
 
 def get_tokens() -> Dict[str, str]:
     """Loads environment variables from dotenv files, and returns them.
-    :return: Dictionary containing DISCORD_TOKEN, ADMIN_ROLE_ID, CHANNEL_ID, and GITHUB_API_KEY key in .env file"""
+    :return: Dictionary containing DISCORD_TOKEN, ADMIN_ROLE_ID, CHANNEL_ID, GITHUB_ORG_NAME,
+    and GITHUB_API_KEY key in .env file"""
     import os
     from dotenv import load_dotenv
     load_dotenv()
-    env_keys = ("DISCORD_TOKEN", "ADMIN_ROLE_ID", "CHANNEL_ID", "GITHUB_API_KEY")
+    env_keys = ("DISCORD_TOKEN", "ADMIN_ROLE_ID", "CHANNEL_ID", "GITHUB_ORG_NAME", "GITHUB_API_KEY")
     return {key: os.getenv(key) for key in env_keys}
 
 
@@ -39,12 +40,19 @@ def setup_database() -> sqlite3.Connection:
     :return: sqlite3.Connection"""
     db_conn = sqlite3.connect('server.db')
     with closing(db_conn.cursor()) as conn:
+        # Create study_time database table.
         table = 'CREATE TABLE IF NOT EXISTS study_time '
         table += '(name text, minutes integer, server text)'
         conn.execute(table)
         db_conn.commit()
+        # Create live_timer database table.
         table = 'CREATE TABLE IF NOT EXISTS live_timer '
         table += '(name text, server text, timestamp real)'
+        db_conn.execute(table)
+        db_conn.commit
+        # Create github_invites database table.
+        table = 'CREATE TABLE IF NOT EXISTS github_invites'
+        table += '(discord_id integer, github_id integer)'
         db_conn.execute(table)
         db_conn.commit()
     return db_conn


### PR DESCRIPTION
I created the GitHub integration cog, which has the commands !github-join and !github-reset.

- Github-join is a user command, that invites the specified user to the organization. It can only be used once per user.
- Github-reset is an admin command, that reset's a users ability to use github-join, and removes the member they previously invited from the organization.

I've tested everything in my test environment, and it is working with no exceptions.

To deploy, you need to add 2 key-value pairs to your .env file: 
- GITHUB_ORG_NAME = Python-Practice-Discord
- GITHUB_API_KEY = This should be a personal access token that is scoped to allow it to invite users to organizations. GitHub applications don't work with pygithub, and OAuth is too complicated for this application. Rather than having any of us use our accounts, one of us can create a bot account with owner access to the org, and generate a personal access token as the bot.

You will also need to install pygithub into the Production environment.


Feel free to merge whenever you want to, but let's not deploy these changes until the day we make the full announcement and make everything public (we can talk in discord about this).